### PR TITLE
fix: getUserFromContext returns user instead of setUser

### DIFF
--- a/client/src/contexts/AuthProvider.tsx
+++ b/client/src/contexts/AuthProvider.tsx
@@ -38,7 +38,7 @@ export const getUserFromContext = () => {
   if (!context) {
     throw new Error("Context must be used within a Provider");
   }
-  return context.setUser;
+  return context.user;
 };
 
 export default AuthProvider;


### PR DESCRIPTION
## Summary

- `getUserFromContext()` was returning `context.setUser` (the setter function) instead of `context.user` (the user object)
- Any consumer of this function was receiving the setter, not the actual user data

## Test plan

- [ ] Log in and verify `getUserFromContext()` returns the user object
- [ ] Confirm no regressions in components consuming this function

## Checklist

- [x] CLAUDE.md updated if models/routes/architecture changed — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)