### PR TITLE
fix: wrap localStorage JSON.parse in try/catch

### DIFF
--- a/client/src/contexts/AuthProvider.tsx
+++ b/client/src/contexts/AuthProvider.tsx
@@ -10,8 +10,13 @@ const AuthContext = createContext<AuthProviderProps | null>(null);
 
 const AuthProvider = ({ children }: PropsWithChildren) => {
   const [user, setUser] = useState<User | null>(() => {
-    const savedUser = localStorage.getItem("user");
-    return savedUser ? JSON.parse(savedUser) : null;
+    try {
+      const savedUser = localStorage.getItem("user");
+      return savedUser ? JSON.parse(savedUser) : null;
+    } catch {
+      localStorage.removeItem("user");
+      return null;
+    }
   });
   useEffect(() => {
     localStorage.setItem("user", JSON.stringify(user));


### PR DESCRIPTION
## Summary

- `JSON.parse(localStorage.getItem("user"))` would throw and crash the app if the stored value was corrupted or malformed
- Wrapped in try/catch — on parse error, clears the bad entry and returns `null` (unauthenticated state)

## Test plan

- [ ] Manually set `localStorage.user` to an invalid JSON string (e.g. `"bad{json"`) and reload — app should load normally in unauthenticated state
- [ ] Normal login/logout flow unaffected

## Checklist

- [x] CLAUDE.md updated if models/routes/architecture changed — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)