### PR TITLE
fix: replace location.replace with router.navigate on 401

### DIFF
--- a/client/src/services/index.ts
+++ b/client/src/services/index.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { routes } from "../Routes";
 
 const axiosClient = axios.create({
   baseURL: import.meta.env.VITE_BACKEND_URL || "http://localhost:3000",
@@ -16,7 +17,7 @@ axiosClient.interceptors.response.use(
     // Check if the response indicates an expired token
     if (response && response.status === 401 && !config.url.includes("/login")) {
       localStorage.removeItem("user");
-      location.replace("/"); // or handle with router
+      routes.navigate("/");
     }
 
     return Promise.reject(error);


### PR DESCRIPTION
## Summary

- `location.replace("/")` on 401 caused a full page reload, blowing away all React/query state
- Replaced with `routes.navigate("/")` using the `createBrowserRouter` instance's built-in `.navigate()` — no extra boilerplate needed
- Also clears `localStorage` user entry before redirecting

## Test plan

- [ ] Trigger a 401 (e.g. manually expire the JWT cookie) and verify redirect to `/` happens without a full page reload
- [ ] Confirm React state (theme, query cache) is preserved through the redirect

## Checklist

- [x] CLAUDE.md updated if models/routes/architecture changed — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)