### PR TITLE
fix: enforce password complexity rules on signup

### DIFF
--- a/backend/src/validations/user.ts
+++ b/backend/src/validations/user.ts
@@ -4,16 +4,17 @@ import { body } from "express-validator";
 export const signupValidation = [
   body("fullName").notEmpty().withMessage("Name is required"),
   body("email").isEmail().withMessage("Invalid email"),
-  body("password").isLength({ min: 6 }).withMessage("Password must be at least 6 characters"),
-  // TODO: uncheck in production
-  // .matches(/\d/)
-  // .withMessage("Password must contain at least one number")
-  // .matches(/[A-Z]/)
-  // .withMessage("Password must contain at least one uppercase letter")
-  // .matches(/[a-z]/)
-  // .withMessage("Password must contain at least one lowercase letter")
-  // .matches(/[!@#$%^&*(),.?":{}|<>]/)
-  // .withMessage("Password must contain at least one special character"),
+  body("password")
+    .isLength({ min: 6 })
+    .withMessage("Password must be at least 6 characters")
+    .matches(/\d/)
+    .withMessage("Password must contain at least one number")
+    .matches(/[A-Z]/)
+    .withMessage("Password must contain at least one uppercase letter")
+    .matches(/[a-z]/)
+    .withMessage("Password must contain at least one lowercase letter")
+    .matches(/[!@#$%^&*(),.?":{}|<>]/)
+    .withMessage("Password must contain at least one special character"),
 ];
 
 export const loginValidation = [


### PR DESCRIPTION
## Summary

- Password complexity checks were commented out, accepting weak passwords like `aaaaaa`
- Enabled all 4 rules: number, uppercase, lowercase, special character (min 6 chars)

## Test plan

- [ ] Signup with `aaaaaa` should now be rejected
- [ ] Signup with a strong password (e.g. `Test@123`) should succeed
- [ ] Google OAuth signup unaffected (no password field)

## Checklist

- [x] CLAUDE.md updated if models/routes/architecture changed — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)