### PR TITLE
fix: throw on missing JWT_SECRET and clear cookie on auth failure

### DIFF
--- a/backend/src/middlewares/authentication.ts
+++ b/backend/src/middlewares/authentication.ts
@@ -6,7 +6,10 @@ import { Types } from "mongoose";
 interface DecodedToken {
   _id: Types.ObjectId;
 }
-const JWT_SECRET = process.env.JWT_SECRET || "your_jwt_secret_key";
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error("JWT_SECRET environment variable is not set");
+}
 
 declare module "express-serve-static-core" {
   export interface Request {
@@ -39,11 +42,11 @@ export const verifyToken = async (
     next(); // Call next middleware
   } catch (error) {
     console.error("Token error", error);
-    // res.clearCookie("jwt", {
-    //   httpOnly: true,
-    //   secure: process.env.NODE_ENV === "production", // Set secure flag in production
-    //   sameSite: "strict", // Adjust based on your needs
-    // });
+    res.clearCookie("jwt", {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "strict",
+    });
     res.status(401).json({ message: "Invalid token" });
   }
 };


### PR DESCRIPTION
## Summary

- **JWT secret fallback removed**: `process.env.JWT_SECRET || "your_jwt_secret_key"` replaced with a hard throw at startup if the env var is missing — prevents all instances silently sharing a known public secret
- **Cookie clearing restored**: `res.clearCookie("jwt")` was commented out in the auth failure handler — re-enabled so invalid JWT cookies are cleared immediately instead of causing repeated 401s

## Test plan

- [ ] Start backend without `JWT_SECRET` in env — server should refuse to start with a clear error
- [ ] Send a request with an invalid/expired JWT cookie — verify the `jwt` cookie is cleared in the response

## Checklist

- [x] CLAUDE.md updated if models/routes/architecture changed — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)