### PR TITLE
fix: validate share URL from searchParams to prevent open redirect

### DIFF
--- a/client/src/layouts/form-summary/ShareTab.tsx
+++ b/client/src/layouts/form-summary/ShareTab.tsx
@@ -3,11 +3,20 @@ import { Input } from "@/components/ui/input";
 import { Copy, ExternalLink } from "lucide-react";
 import { Link, useSearchParams } from "react-router-dom";
 
+const ALLOWED_URL_PREFIX = "/view-form/";
+
+const getSafeShareUrl = (raw: string | null): string => {
+  if (!raw || !raw.startsWith(ALLOWED_URL_PREFIX)) return "";
+  return window.location.origin + raw;
+};
+
 const ShareTab = () => {
   const [searchParams] = useSearchParams();
+  const shareUrl = getSafeShareUrl(searchParams.get("url"));
+
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(window.location.origin + searchParams.get("url") || "");
+      await navigator.clipboard.writeText(shareUrl);
     } catch (err) {
       console.error("Failed to copy text: ", err);
     }
@@ -24,12 +33,12 @@ const ShareTab = () => {
         </div>
         <div className="flex gap-2">
           <Input
-            value={window.location.origin + searchParams.get("url") || ""}
+            value={shareUrl}
             readOnly
             className="flex-1"
           />
           <Link
-            to={window.location.origin + searchParams.get("url") || ""}
+            to={shareUrl}
             target="_blank"
           >
             <Button


### PR DESCRIPTION
## Summary

- `searchParams.get("url")` was used directly with no validation — a crafted URL like `?url=//evil.com` could redirect users to an external site or inject content
- Added `getSafeShareUrl()` which only accepts paths starting with `/view-form/`, returning empty string for anything else
- All three usages (input value, copy handler, Link `to` prop) now use the validated URL

## Test plan

- [ ] Navigate to `/form-summary/:id?url=/view-form/abc` — share URL displays correctly
- [ ] Navigate with `?url=//evil.com` or `?url=/dashboard` — input shows empty, link is inert
- [ ] Copy button copies the validated URL

## Checklist

- [x] CLAUDE.md updated if models/routes/architecture changed — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)