### PR TITLE
fix: add missing error handling across FormView, Dashboard, ShareTab

### DIFF
--- a/client/src/layouts/form-summary/ShareTab.tsx
+++ b/client/src/layouts/form-summary/ShareTab.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Copy, ExternalLink } from "lucide-react";
 import { Link, useSearchParams } from "react-router-dom";
+import { toast } from "sonner";
 
 const ALLOWED_URL_PREFIX = "/view-form/";
 
@@ -17,8 +18,9 @@ const ShareTab = () => {
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(shareUrl);
-    } catch (err) {
-      console.error("Failed to copy text: ", err);
+      toast.success("Link copied to clipboard");
+    } catch {
+      toast.error("Failed to copy link. Please copy it manually.");
     }
   };
   return (

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -37,6 +37,14 @@ const DashboardPage = () => {
   });
   const navigate = useNavigate();
 
+  if (isError) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <p className="text-muted-foreground">Failed to load dashboard. Please refresh the page.</p>
+      </div>
+    );
+  }
+
   const allForms: FormType[] = dashboard?.workspaces?.flatMap((workspace: WorkspaceType) =>
     workspace.forms.map(form => ({ ...form, workspaceId: workspace._id })),
   );
@@ -50,15 +58,13 @@ const DashboardPage = () => {
     <div className="px-5">
       <PageTitle>Home</PageTitle>
       <main className="mx-auto max-w-[1100px] overflow-auto flex-grow container ">
-        {!isError && (
-          <div className="">
-            <h1 className="text-lg font-semibold">Quickstart</h1>
-            <div className="flex gap-2 mt-4">
-              <HomeWorkspaceCard />
-              <HomeStatsCard isLoading={isLoading} />
-            </div>
+        <div className="">
+          <h1 className="text-lg font-semibold">Quickstart</h1>
+          <div className="flex gap-2 mt-4">
+            <HomeWorkspaceCard />
+            <HomeStatsCard isLoading={isLoading} />
           </div>
-        )}
+        </div>
         <Tabs
           defaultValue="all"
           className="mt-12"
@@ -71,7 +77,7 @@ const DashboardPage = () => {
             className="mt-4"
           >
             <div className="grid gap-4">
-              {!isError && dashboard?.workspaces?.length > 0 ? (
+              {dashboard?.workspaces?.length > 0 ? (
                 <Table>
                   <TableHeader>
                     <TableRow>
@@ -149,7 +155,7 @@ const DashboardPage = () => {
             className="mt-4"
           >
             <div className="grid gap-4">
-              {!isError && allForms?.length > 0 ? (
+              {allForms?.length > 0 ? (
                 <Table>
                   <TableHeader>
                     <TableRow>

--- a/client/src/pages/FormView.tsx
+++ b/client/src/pages/FormView.tsx
@@ -10,6 +10,8 @@ import { useNavigate, useParams } from "react-router-dom";
 import NotFoundPage from "./NotFound";
 import { Loader2Icon } from "lucide-react";
 import { BlockData } from "@shared/types";
+import { toast } from "sonner";
+import { AxiosError } from "axios";
 
 interface Form {
   _id: string;
@@ -25,7 +27,11 @@ interface MCQOptions {
 const FormViewPage = () => {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
-  const { data, isLoading } = useQuery<Form>({
+  const {
+    data,
+    isLoading,
+    isError: isFormError,
+  } = useQuery<Form>({
     queryKey: ["form", id],
     queryFn: () => viewForm(id),
     staleTime: 10000,
@@ -71,6 +77,9 @@ const FormViewPage = () => {
       navigate("/success", { replace: true });
       queryClient.invalidateQueries({ queryKey: ["dashboard"] });
     },
+    onError: (error: AxiosError<{ message: string }>) => {
+      toast.error(error.response?.data?.message || "Failed to submit form. Please try again.");
+    },
   });
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -80,6 +89,16 @@ const FormViewPage = () => {
       _id: data?._id || "",
     });
   };
+
+  if (isFormError) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <p className="text-muted-foreground">
+          Failed to load form. Please check the link and try again.
+        </p>
+      </div>
+    );
+  }
 
   if (data?.disabled) {
     return <NotFoundPage />;


### PR DESCRIPTION
## Summary

Sprint 4 — Error Handling. Closes all gaps identified in the audit.

- **FormView**: Add `onError` toast to form submission mutation; show error message when form query fails instead of a blank screen
- **Dashboard**: Early-return with a visible error message when the dashboard query fails; remove `!isError` guards in JSX that were silently hiding content with no user feedback
- **ShareTab**: Replace `console.error` with `toast.error` on clipboard failure; add `toast.success` on successful copy

## Test plan
- [ ] Submit a form while backend is down — toast error appears
- [ ] Visit a bad form URL — error message shown instead of blank screen
- [ ] Load dashboard while backend is down — error message shown
- [ ] Copy share link — success toast appears; block clipboard permission and confirm error toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)