### PR TITLE
feat: avatar upload, appearance tab, disabled badge (sprint 5)

### DIFF
--- a/client/src/layouts/settings/AppearanceTab.tsx
+++ b/client/src/layouts/settings/AppearanceTab.tsx
@@ -6,24 +6,24 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { useState } from "react";
+import { useTheme } from "@/contexts/ThemeProvider";
+
 const AppearanceTab = () => {
-  const [language, setLanguage] = useState<string>("en");
+  const { theme, setTheme } = useTheme();
   return (
     <div className="space-y-2">
-      <Label htmlFor="language">Language</Label>
+      <Label htmlFor="theme">Theme</Label>
       <Select
-        value={language}
-        onValueChange={setLanguage}
+        value={theme}
+        onValueChange={value => setTheme(value as "light" | "dark" | "system")}
       >
-        <SelectTrigger id="language">
-          <SelectValue placeholder="Select a language" />
+        <SelectTrigger id="theme">
+          <SelectValue placeholder="Select a theme" />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="en">English</SelectItem>
-          <SelectItem value="es">Español</SelectItem>
-          <SelectItem value="fr">Français</SelectItem>
-          <SelectItem value="de">Deutsch</SelectItem>
+          <SelectItem value="light">Light</SelectItem>
+          <SelectItem value="dark">Dark</SelectItem>
+          <SelectItem value="system">System</SelectItem>
         </SelectContent>
       </Select>
     </div>

--- a/client/src/layouts/settings/ProfileTab.tsx
+++ b/client/src/layouts/settings/ProfileTab.tsx
@@ -11,8 +11,8 @@ import { AxiosError } from "axios";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 
-// const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
-// const ALLOWED_TYPES = ["image/jpeg", "image/jpg"];
+const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB
+const ALLOWED_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp"];
 
 const ProfileTab = ({
   profile,
@@ -32,40 +32,31 @@ const ProfileTab = ({
   const { mutate: updateUser, isPending } = useMutation({
     mutationFn: (userData: UserProfile) => updateUserDetails(userData),
     onSuccess: () => {
-      // Boom baby!
       queryClient.invalidateQueries({ queryKey: ["user"] });
       toast.success("Profile updated successfully");
     },
     onError: (error: AxiosError<{ message: string }>) => {
-      // An error happened!
-      toast.error(
-        error.response?.data?.message?.includes("User validation failed")
-          ? "User data validation failed"
-          : "Something went wrong",
-      );
+      toast.error(error.response?.data?.message || "Failed to update profile");
     },
   });
-  // const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-  //   const file = e.target.files?.[0];
-  //   if (file) {
-  //     // Validate file size and type
-  //     if (file.size > MAX_FILE_SIZE) {
-  //       toast.error("File size exceeds 2MB limit");
-  //       return;
-  //     }
-  //     if (!ALLOWED_TYPES.includes(file.type)) {
-  //       toast.error("Only JPG/JPEG files are allowed");
-  //       return;
-  //     }
 
-  //     // If valid, update profile with new avatar
-  //     // const reader = new FileReader();
-  //     // reader.onload = () => {
-  //     //   setProfile({ ...profile, avatar: reader.result as string });
-  //     // };
-  //     // reader.readAsDataURL(file);
-  //   }
-  // };
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (file.size > MAX_FILE_SIZE) {
+      toast.error("File size exceeds 2MB limit");
+      return;
+    }
+    if (!ALLOWED_TYPES.includes(file.type)) {
+      toast.error("Only JPG, PNG, or WebP files are allowed");
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      setProfile({ ...profile, avatar: reader.result as string });
+    };
+    reader.readAsDataURL(file);
+  };
   return (
     <form
       onSubmit={handleProfileUpdate}
@@ -84,13 +75,11 @@ const ProfileTab = ({
             <AvatarFallback>{profile.fullName?.charAt(0)}</AvatarFallback>
           </Avatar>
         )}
-        {/* {isLoading ? (
-          <Skeleton className="h-[36px] w-[133px]" />
-        ) : (
+        {!isLoading && (
           <>
             <input
               type="file"
-              accept="image/jpeg, image/jpg"
+              accept="image/jpeg,image/jpg,image/png,image/webp"
               style={{ display: "none" }}
               id="avatar-upload"
               onChange={handleFileChange}
@@ -103,7 +92,7 @@ const ProfileTab = ({
               Change Avatar
             </Button>
           </>
-        )} */}
+        )}
       </div>
       <div className="space-y-2">
         {isLoading ? <Skeleton className="h-4 w-20" /> : <Label htmlFor="name">Name </Label>}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/empty";
 import { FileText } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 
 const DashboardPage = () => {
   const {
@@ -172,13 +173,16 @@ const DashboardPage = () => {
                         className="group"
                       >
                         <TableCell className="w-[20%] font-bold">
-                          <Link
-                            to={`/form-summary/${form.form_id}?name=${form.name}&submission=${form.submissions}&url=${form.url}&modified=${form.modified}&created=${form.created}`}
-                            onClick={e => e.stopPropagation()}
-                            className="group-hover:underline"
-                          >
-                            {form.name}
-                          </Link>
+                          <div className="flex items-center gap-2">
+                            <Link
+                              to={`/form-summary/${form.form_id}?name=${form.name}&submission=${form.submissions}&url=${form.url}&modified=${form.modified}&created=${form.created}`}
+                              onClick={e => e.stopPropagation()}
+                              className="group-hover:underline"
+                            >
+                              {form.name}
+                            </Link>
+                            {form.disabled && <Badge variant="secondary">Disabled</Badge>}
+                          </div>
                         </TableCell>
                         <TableCell className="w-[20%]">{form.submissions}</TableCell>
                         <TableCell className="w-[20%]">

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -39,10 +39,7 @@ const SettingsPage = () => {
           <TabsList>
             <TabsTrigger value="profile">Profile</TabsTrigger>
             <TabsTrigger value="account">Account</TabsTrigger>
-            {/* <TabsTrigger value="notifications" disabled={true}>
-              Notifications
-            </TabsTrigger> */}
-            {/* <TabsTrigger value="appearance">Appearance</TabsTrigger> */}
+            <TabsTrigger value="appearance">Appearance</TabsTrigger>
           </TabsList>
 
           <TabsContent value="profile">


### PR DESCRIPTION
## Summary

Sprint 5 — first batch of UI completions.

### Avatar upload
- Uncomment and complete the file upload flow in ProfileTab
- User selects JPG/PNG/WebP (max 2MB), read as base64 data URL via FileReader, saved with profile on submit
- Broadened accepted types from JPG-only to JPG/PNG/WebP

### Appearance tab
- Wire `AppearanceTab` theme selector to `ThemeProvider` (`useTheme`)
- Replaced unused language selector with light/dark/system theme picker
- Uncomment the Appearance tab trigger in Settings so it's visible

### Disabled badge in Dashboard
- Forms with `disabled: true` now show a "Disabled" badge next to their name in the all-forms table

## Test plan
- [ ] Upload avatar in Settings → Profile; confirm it appears in the avatar component
- [ ] Upload oversized or wrong-type file — toast error shown
- [ ] Switch theme in Settings → Appearance; confirm it persists on reload
- [ ] Disable a form via form summary settings; confirm badge appears on Dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)