### PR TITLE
feat: sprint 5 batch 2 — dashboard filter tabs, CSV export

### DIFF
--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -49,6 +49,8 @@ const DashboardPage = () => {
   const allForms: FormType[] = dashboard?.workspaces?.flatMap((workspace: WorkspaceType) =>
     workspace.forms.map(form => ({ ...form, workspaceId: workspace._id })),
   );
+  const activeForms = allForms?.filter(f => !f.disabled);
+  const disabledForms = allForms?.filter(f => f.disabled);
 
   const workspaces: WorkspaceType[] = dashboard?.workspaces || [];
 
@@ -138,18 +140,8 @@ const DashboardPage = () => {
         >
           <TabsList>
             <TabsTrigger value="all">All Forms</TabsTrigger>
-            <TabsTrigger
-              value="published"
-              disabled
-            >
-              Published
-            </TabsTrigger>
-            <TabsTrigger
-              value="drafts"
-              disabled
-            >
-              Drafts
-            </TabsTrigger>
+            <TabsTrigger value="active">Active</TabsTrigger>
+            <TabsTrigger value="disabled">Disabled</TabsTrigger>
           </TabsList>
           <TabsContent
             value="all"
@@ -231,13 +223,117 @@ const DashboardPage = () => {
             </div>
           </TabsContent>
           <TabsContent
-            value="published"
+            value="active"
             className="mt-4"
-          />
+          >
+            <div className="grid gap-4">
+              {activeForms?.length > 0 ? (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-[20%]">Name</TableHead>
+                      <TableHead className="w-[20%]">Submissions</TableHead>
+                      <TableHead className="w-[20%]">Created</TableHead>
+                      <TableHead className="w-[20%] text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {activeForms.map(form => (
+                      <TableRow
+                        key={form._id}
+                        className="group"
+                      >
+                        <TableCell className="w-[20%] font-bold">
+                          <Link
+                            to={`/form-summary/${form.form_id}?name=${form.name}&submission=${form.submissions}&url=${form.url}&modified=${form.modified}&created=${form.created}`}
+                            onClick={e => e.stopPropagation()}
+                            className="group-hover:underline"
+                          >
+                            {form.name}
+                          </Link>
+                        </TableCell>
+                        <TableCell className="w-[20%]">{form.submissions}</TableCell>
+                        <TableCell className="w-[20%]">
+                          {new Date(form.created).toLocaleDateString("en-US")}
+                        </TableCell>
+                        <TableCell className="w-[20%] text-right space-x-3 font-semibold text-primary">
+                          <Link
+                            to={`/view-form/${form.form_id}`}
+                            target="_blank"
+                            onClick={e => e.stopPropagation()}
+                            className="hover:underline"
+                          >
+                            View
+                          </Link>
+                          <Link
+                            to={`/form/${form.form_id}`}
+                            onClick={e => e.stopPropagation()}
+                            className="hover:underline"
+                          >
+                            Edit
+                          </Link>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              ) : (
+                <p className="text-muted-foreground text-center my-16">No active forms.</p>
+              )}
+            </div>
+          </TabsContent>
           <TabsContent
-            value="drafts"
+            value="disabled"
             className="mt-4"
-          />
+          >
+            <div className="grid gap-4">
+              {disabledForms?.length > 0 ? (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-[20%]">Name</TableHead>
+                      <TableHead className="w-[20%]">Submissions</TableHead>
+                      <TableHead className="w-[20%]">Created</TableHead>
+                      <TableHead className="w-[20%] text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {disabledForms.map(form => (
+                      <TableRow
+                        key={form._id}
+                        className="group"
+                      >
+                        <TableCell className="w-[20%] font-bold">
+                          <Link
+                            to={`/form-summary/${form.form_id}?name=${form.name}&submission=${form.submissions}&url=${form.url}&modified=${form.modified}&created=${form.created}`}
+                            onClick={e => e.stopPropagation()}
+                            className="group-hover:underline"
+                          >
+                            {form.name}
+                          </Link>
+                        </TableCell>
+                        <TableCell className="w-[20%]">{form.submissions}</TableCell>
+                        <TableCell className="w-[20%]">
+                          {new Date(form.created).toLocaleDateString("en-US")}
+                        </TableCell>
+                        <TableCell className="w-[20%] text-right space-x-3 font-semibold text-primary">
+                          <Link
+                            to={`/form/${form.form_id}`}
+                            onClick={e => e.stopPropagation()}
+                            className="hover:underline"
+                          >
+                            Edit
+                          </Link>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              ) : (
+                <p className="text-muted-foreground text-center my-16">No disabled forms.</p>
+              )}
+            </div>
+          </TabsContent>
         </Tabs>
       </main>
     </div>

--- a/client/src/pages/FormSummary.tsx
+++ b/client/src/pages/FormSummary.tsx
@@ -1,7 +1,8 @@
 import PageTitle from "@/components/common/PageTitle";
 import { Button } from "@/components/ui/button";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { EditIcon } from "lucide-react";
+import { EditIcon, DownloadIcon } from "lucide-react";
+import { OptionsBlockData } from "@shared/types";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { fetchSubmissions, viewForm } from "@/services/form";
 import { useQuery } from "@tanstack/react-query";
@@ -35,8 +36,32 @@ const FormSummaryPage = () => {
   });
 
   const navigate = useNavigate();
-
   const isLoading = isSubmissionsLoading || isFormViewLoading;
+
+  const handleExportCSV = () => {
+    if (!submissions || !formView) return;
+    const headers = ["Submitted At", ...formView.blocks.map(b => b.data?.title || "")];
+    const rows = submissions.map(sub => [
+      new Date(sub.createdAt).toLocaleString(),
+      ...sub.blocks.map(block =>
+        block.type === "multipleChoiceTool"
+          ? block.data.options?.find(
+              (o: OptionsBlockData) => o.optionMarker === block.data.selectedOption,
+            )?.optionValue || ""
+          : block.data.value || "",
+      ),
+    ]);
+    const csv = [headers, ...rows]
+      .map(row => row.map(cell => `"${String(cell).replace(/"/g, '""')}"`).join(","))
+      .join("\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${searchParams.get("name") || "submissions"}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
   return (
     <div className="px-5">
       <PageTitle>
@@ -87,10 +112,22 @@ const FormSummaryPage = () => {
                 )}
               </div>
             ) : (
-              <SubmissionsTable
-                formView={formView}
-                submissions={submissions}
-              />
+              <div>
+                <div className="flex justify-end mb-3">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleExportCSV}
+                  >
+                    <DownloadIcon className="w-4 h-4 mr-2" />
+                    Export CSV
+                  </Button>
+                </div>
+                <SubmissionsTable
+                  formView={formView}
+                  submissions={submissions}
+                />
+              </div>
             )}
           </TabsContent>
           <TabsContent value="share">


### PR DESCRIPTION
## Summary

- Dashboard Active/Disabled filter tabs (client-side filter)
- CSV export for submissions (client-side, no backend needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)