### PR TITLE
feat: add email, date, rating, and dropdown block types

### DIFF
--- a/client/src/components/form/tools/DateTool.tsx
+++ b/client/src/components/form/tools/DateTool.tsx
@@ -1,0 +1,72 @@
+import { API, BlockAPI, BlockToolData } from "@editorjs/editorjs";
+import * as ReactDOMClient from "react-dom/client";
+import QuestionTitle from "../ui/QuestionTitle";
+import { Input } from "@/components/ui/input";
+
+interface DateToolDataInterface extends BlockToolData {
+  title: string;
+  required: boolean;
+}
+
+export default class DateTool {
+  static get toolbox() {
+    return {
+      title: "Date",
+      icon: '<svg width="10" height="10" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6.5 1C6.78 1 7 1.22 7 1.5V3H13V1.5C13 1.22 13.22 1 13.5 1C13.78 1 14 1.22 14 1.5V3H16C16.55 3 17 3.45 17 4V17C17 17.55 16.55 18 16 18H4C3.45 18 3 17.55 3 17V4C3 3.45 3.45 3 4 3H6V1.5C6 1.22 6.22 1 6.5 1ZM4 7V17H16V7H4ZM4 4V6H16V4H4Z" fill="currentColor"/>',
+    };
+  }
+
+  wrapper: HTMLElement | undefined;
+  api: API;
+  data: DateToolDataInterface;
+  block: BlockAPI;
+
+  constructor({ api, data, block }: { api: API; block: BlockAPI; data: DateToolDataInterface }) {
+    this.api = api;
+    this.block = block;
+    this.data = Object.keys(data).length ? data : { title: "", required: false };
+    this.wrapper = undefined;
+  }
+
+  render() {
+    this.wrapper = document.createElement("div");
+    this.wrapper.classList.add("date-block");
+
+    const onKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement | HTMLDivElement>) => {
+      if (event.key === "Backspace" && this.data.title === "") {
+        const currentIndex = this.api.blocks.getCurrentBlockIndex();
+        this.api.blocks.delete(currentIndex);
+        requestAnimationFrame(() => {
+          if (currentIndex > 0) {
+            this.api.caret.setToBlock(currentIndex - 1, "end");
+          }
+        });
+      }
+    };
+
+    const root = ReactDOMClient.createRoot(this.wrapper);
+    root.render(
+      <div>
+        <QuestionTitle
+          placeholder="Type your question here"
+          onInput={value => {
+            this.data.title = value;
+          }}
+          onKeyDown={onKeyDown}
+          question={this.data.title}
+        />
+        <Input
+          type="date"
+          className="focus-visible:ring-0 my-2 w-[60%]"
+          readOnly
+          tabIndex={-1}
+        />
+      </div>,
+    );
+    return this.wrapper;
+  }
+
+  save(): DateToolDataInterface {
+    return { ...this.data };
+  }
+}

--- a/client/src/components/form/tools/DropdownTool.tsx
+++ b/client/src/components/form/tools/DropdownTool.tsx
@@ -1,0 +1,101 @@
+import { API, BlockAPI, BlockToolData } from "@editorjs/editorjs";
+import * as ReactDOMClient from "react-dom/client";
+import QuestionTitle from "../ui/QuestionTitle";
+import MultipleChoiceOption from "../ui/MultipleChoiceOption";
+
+interface DropdownToolDataInterface extends BlockToolData {
+  title: string;
+  options: Array<{ optionValue: string; optionMarker: string }>;
+  required: boolean;
+}
+
+export default class DropdownTool {
+  static get toolbox() {
+    return {
+      title: "Dropdown",
+      icon: '<svg width="10" height="10" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M3 5.5C3 4.67 3.67 4 4.5 4H15.5C16.33 4 17 4.67 17 5.5V14.5C17 15.33 16.33 16 15.5 16H4.5C3.67 16 3 15.33 3 14.5V5.5ZM4.5 5C4.22 5 4 5.22 4 5.5V14.5C4 14.78 4.22 15 4.5 15H15.5C15.78 15 16 14.78 16 14.5V5.5C16 5.22 15.78 5 15.5 5H4.5ZM10 11.5L7 8.5H13L10 11.5Z" fill="currentColor"/>',
+    };
+  }
+
+  wrapper: HTMLElement | undefined;
+  api: API;
+  data: DropdownToolDataInterface;
+  block: BlockAPI;
+
+  constructor({
+    api,
+    data,
+    block,
+  }: {
+    api: API;
+    block: BlockAPI;
+    data: DropdownToolDataInterface;
+  }) {
+    this.api = api;
+    this.block = block;
+    this.data = Object.keys(data).length
+      ? data
+      : { title: "", options: [{ optionMarker: "a", optionValue: "" }], required: false };
+    this.wrapper = undefined;
+  }
+
+  render() {
+    this.wrapper = document.createElement("div");
+    this.wrapper.classList.add("dropdown-block");
+
+    const onKeyDown = (
+      event: React.KeyboardEvent<HTMLTextAreaElement | HTMLDivElement>,
+      idx: number | undefined,
+    ) => {
+      if (event.key === "Backspace") {
+        if (this.data.options.length > 0 && this.data.options[0].optionValue === "") {
+          if (this.data.title === "") {
+            const currentIndex = this.api.blocks.getCurrentBlockIndex();
+            this.api.blocks.delete(currentIndex);
+            requestAnimationFrame(() => {
+              if (currentIndex > 0) {
+                this.api.caret.setToBlock(currentIndex - 1, "end");
+              }
+            });
+          }
+        } else {
+          this.data.options.filter((_, index) => index !== idx);
+        }
+      }
+    };
+
+    const root = ReactDOMClient.createRoot(this.wrapper);
+    root.render(
+      <div>
+        <QuestionTitle
+          placeholder="Type your question here"
+          onInput={value => {
+            this.data.title = value;
+          }}
+          onKeyDown={onKeyDown}
+          question={this.data.title}
+        />
+        <div className="my-2 w-[60%] flex h-10 items-center rounded-md border border-input bg-background px-3 py-2 text-sm text-muted-foreground">
+          Select an option ▾
+        </div>
+        <div className="mt-3">
+          <MultipleChoiceOption
+            optionsProp={this.data.options}
+            onLastOptionKeyDown={onKeyDown}
+            onAddNewOption={options => {
+              this.data.options = options;
+            }}
+            onInputChange={options => {
+              this.data.options = options;
+            }}
+          />
+        </div>
+      </div>,
+    );
+    return this.wrapper;
+  }
+
+  save(): DropdownToolDataInterface {
+    return { ...this.data };
+  }
+}

--- a/client/src/components/form/tools/EmailTool.tsx
+++ b/client/src/components/form/tools/EmailTool.tsx
@@ -1,0 +1,74 @@
+import { API, BlockAPI, BlockToolData } from "@editorjs/editorjs";
+import * as ReactDOMClient from "react-dom/client";
+import QuestionTitle from "../ui/QuestionTitle";
+import { Input } from "@/components/ui/input";
+
+interface EmailToolDataInterface extends BlockToolData {
+  title: string;
+  required: boolean;
+  placeholder?: string;
+}
+
+export default class EmailTool {
+  static get toolbox() {
+    return {
+      title: "Email",
+      icon: '<svg width="10" height="10" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M2.5 4.5C2.5 3.67 3.17 3 4 3H16C16.83 3 17.5 3.67 17.5 4.5V15.5C17.5 16.33 16.83 17 16 17H4C3.17 17 2.5 16.33 2.5 15.5V4.5ZM4 4L10 9.5L16 4H4ZM16.5 5.09L10.32 10.79C10.14 10.93 9.86 10.93 9.68 10.79L3.5 5.09V15.5C3.5 15.78 3.72 16 4 16H16C16.28 16 16.5 15.78 16.5 15.5V5.09Z" fill="currentColor"/>',
+    };
+  }
+
+  wrapper: HTMLElement | undefined;
+  api: API;
+  data: EmailToolDataInterface;
+  block: BlockAPI;
+
+  constructor({ api, data, block }: { api: API; block: BlockAPI; data: EmailToolDataInterface }) {
+    this.api = api;
+    this.block = block;
+    this.data = Object.keys(data).length ? data : { title: "", required: false, placeholder: "" };
+    this.wrapper = undefined;
+  }
+
+  render() {
+    this.wrapper = document.createElement("div");
+    this.wrapper.classList.add("email-block");
+
+    const onKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement | HTMLDivElement>) => {
+      if (event.key === "Backspace" && this.data.title === "") {
+        const currentIndex = this.api.blocks.getCurrentBlockIndex();
+        this.api.blocks.delete(currentIndex);
+        requestAnimationFrame(() => {
+          if (currentIndex > 0) {
+            this.api.caret.setToBlock(currentIndex - 1, "end");
+          }
+        });
+      }
+    };
+
+    const root = ReactDOMClient.createRoot(this.wrapper);
+    root.render(
+      <div>
+        <QuestionTitle
+          placeholder="Type your question here"
+          onInput={value => {
+            this.data.title = value;
+          }}
+          onKeyDown={onKeyDown}
+          question={this.data.title}
+        />
+        <Input
+          type="email"
+          placeholder="Email address"
+          className="focus-visible:ring-0 my-2 w-[60%]"
+          readOnly
+          tabIndex={-1}
+        />
+      </div>,
+    );
+    return this.wrapper;
+  }
+
+  save(): EmailToolDataInterface {
+    return { ...this.data };
+  }
+}

--- a/client/src/components/form/tools/RatingTool.tsx
+++ b/client/src/components/form/tools/RatingTool.tsx
@@ -1,0 +1,72 @@
+import { API, BlockAPI, BlockToolData } from "@editorjs/editorjs";
+import * as ReactDOMClient from "react-dom/client";
+import QuestionTitle from "../ui/QuestionTitle";
+import RatingInput from "../ui/RatingInput";
+
+interface RatingToolDataInterface extends BlockToolData {
+  title: string;
+  required: boolean;
+  maxRating: number;
+}
+
+export default class RatingTool {
+  static get toolbox() {
+    return {
+      title: "Rating",
+      icon: '<svg width="10" height="10" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M10 1.5L12.39 6.26L17.5 7.27L13.75 11.01L14.78 16.5L10 13.77L5.22 16.5L6.25 11.01L2.5 7.27L7.61 6.26L10 1.5Z" fill="currentColor"/>',
+    };
+  }
+
+  wrapper: HTMLElement | undefined;
+  api: API;
+  data: RatingToolDataInterface;
+  block: BlockAPI;
+
+  constructor({ api, data, block }: { api: API; block: BlockAPI; data: RatingToolDataInterface }) {
+    this.api = api;
+    this.block = block;
+    this.data = Object.keys(data).length ? data : { title: "", required: false, maxRating: 5 };
+    this.wrapper = undefined;
+  }
+
+  render() {
+    this.wrapper = document.createElement("div");
+    this.wrapper.classList.add("rating-block");
+
+    const onKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement | HTMLDivElement>) => {
+      if (event.key === "Backspace" && this.data.title === "") {
+        const currentIndex = this.api.blocks.getCurrentBlockIndex();
+        this.api.blocks.delete(currentIndex);
+        requestAnimationFrame(() => {
+          if (currentIndex > 0) {
+            this.api.caret.setToBlock(currentIndex - 1, "end");
+          }
+        });
+      }
+    };
+
+    const root = ReactDOMClient.createRoot(this.wrapper);
+    root.render(
+      <div>
+        <QuestionTitle
+          placeholder="Type your question here"
+          onInput={value => {
+            this.data.title = value;
+          }}
+          onKeyDown={onKeyDown}
+          question={this.data.title}
+        />
+        <RatingInput
+          value={0}
+          maxRating={this.data.maxRating}
+          onChange={() => {}}
+        />
+      </div>,
+    );
+    return this.wrapper;
+  }
+
+  save(): RatingToolDataInterface {
+    return { ...this.data };
+  }
+}

--- a/client/src/components/form/ui/RatingInput.tsx
+++ b/client/src/components/form/ui/RatingInput.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from "react";
+
+interface RatingInputProps {
+  value: number;
+  maxRating: number;
+  onChange: (value: number) => void;
+}
+
+const RatingInput: React.FC<RatingInputProps> = ({ value, maxRating, onChange }) => {
+  const [hovered, setHovered] = useState(0);
+
+  return (
+    <div className="flex gap-1 my-2">
+      {Array.from({ length: maxRating }, (_, i) => i + 1).map(star => (
+        <button
+          key={star}
+          type="button"
+          className="text-2xl focus:outline-none transition-colors"
+          style={{ color: star <= (hovered || value) ? "#f59e0b" : "#d1d5db" }}
+          onMouseEnter={() => setHovered(star)}
+          onMouseLeave={() => setHovered(0)}
+          onClick={() => onChange(star)}
+        >
+          ★
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default RatingInput;

--- a/client/src/layouts/form/Editor.tsx
+++ b/client/src/layouts/form/Editor.tsx
@@ -15,6 +15,10 @@ import { FormDataInterface } from "@shared/types";
 import QuestionTitleTool from "@/components/form/tools/QuestionTitleTool.tsx";
 import ShortAnswerCompositeTool from "@/components/form/tools/ShortAnswerCompositeTool.tsx";
 import LongAnswerCompositeTool from "@/components/form/tools/LongAnswerCompositeTool.tsx";
+import EmailTool from "@/components/form/tools/EmailTool.tsx";
+import DateTool from "@/components/form/tools/DateTool.tsx";
+import RatingTool from "@/components/form/tools/RatingTool.tsx";
+import DropdownTool from "@/components/form/tools/DropdownTool.tsx";
 
 const Editor = () => {
   const { id } = useParams();
@@ -45,6 +49,11 @@ const Editor = () => {
           // Composite tool (visible in toolbox)
           shortAnswerQuestion: ShortAnswerCompositeTool,
           longAnswerQuestion: LongAnswerCompositeTool,
+          // New block types
+          emailTool: EmailTool,
+          dateTool: DateTool,
+          ratingTool: RatingTool,
+          dropdownTool: DropdownTool,
         },
         onChange: throttle(() => {
           editorInstance.current

--- a/client/src/pages/FormView.tsx
+++ b/client/src/pages/FormView.tsx
@@ -3,6 +3,13 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { submitForm, SubmitFormData, viewForm } from "@/services/form";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
@@ -12,6 +19,7 @@ import { Loader2Icon } from "lucide-react";
 import { BlockData } from "@shared/types";
 import { toast } from "sonner";
 import { AxiosError } from "axios";
+import RatingInput from "@/components/form/ui/RatingInput";
 
 interface Form {
   _id: string;
@@ -46,26 +54,20 @@ const FormViewPage = () => {
   const handleChange = (blockId: string, value: string, type: string) => {
     const newFormState = formState.map(block => {
       if (block._id === blockId) {
-        if (type === "shortAnswerTool" || type === "longAnswerTool") {
-          return {
-            ...block,
-            data: {
-              ...block.data,
-              value: value, // Assuming you're updating the placeholder field
-            },
-          };
-        } else if (type === "multipleChoiceTool") {
-          return {
-            ...block,
-            data: {
-              ...block.data,
-              selectedOption: value, // Store the selected option marker
-              // Assuming you're updating the options array
-            },
-          };
+        if (
+          type === "shortAnswerTool" ||
+          type === "longAnswerTool" ||
+          type === "emailTool" ||
+          type === "dateTool"
+        ) {
+          return { ...block, data: { ...block.data, value } };
+        } else if (type === "multipleChoiceTool" || type === "dropdownTool") {
+          return { ...block, data: { ...block.data, selectedOption: value } };
+        } else if (type === "ratingTool") {
+          return { ...block, data: { ...block.data, value } };
         }
       }
-      return block; // If _id doesn't match, return block unchanged
+      return block;
     });
     setFormState(newFormState);
   };
@@ -187,6 +189,68 @@ const FormViewPage = () => {
                                 </div>
                               </button>
                             ))}
+                          </div>
+                        </div>
+                      );
+                    case "emailTool":
+                      return (
+                        <div key={block._id}>
+                          <label className="font-semibold py-2 px-0">{block.data?.title}</label>
+                          <Input
+                            type="email"
+                            placeholder="Email address"
+                            className="focus-visible:ring-0 my-2 w-[60%]"
+                            value={block.data?.value || ""}
+                            onChange={e => handleChange(block._id, e.target.value, block.type)}
+                          />
+                        </div>
+                      );
+                    case "dateTool":
+                      return (
+                        <div key={block._id}>
+                          <label className="font-semibold py-2 px-0">{block.data?.title}</label>
+                          <Input
+                            type="date"
+                            className="focus-visible:ring-0 my-2 w-[60%]"
+                            value={block.data?.value || ""}
+                            onChange={e => handleChange(block._id, e.target.value, block.type)}
+                          />
+                        </div>
+                      );
+                    case "ratingTool":
+                      return (
+                        <div key={block._id}>
+                          <label className="font-semibold py-2 px-0">{block.data?.title}</label>
+                          <RatingInput
+                            value={Number(block.data?.value) || 0}
+                            maxRating={block.data?.maxRating || 5}
+                            onChange={val => handleChange(block._id, String(val), block.type)}
+                          />
+                        </div>
+                      );
+                    case "dropdownTool":
+                      return (
+                        <div key={block._id}>
+                          <label className="font-semibold py-2 px-0">{block.data?.title}</label>
+                          <div className="my-2 w-[60%]">
+                            <Select
+                              value={block.data?.selectedOption || ""}
+                              onValueChange={val => handleChange(block._id, val, block.type)}
+                            >
+                              <SelectTrigger className="focus:ring-0">
+                                <SelectValue placeholder="Select an option" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                {block.data.options?.map((option: MCQOptions) => (
+                                  <SelectItem
+                                    key={option.optionMarker}
+                                    value={option.optionMarker}
+                                  >
+                                    {option.optionValue}
+                                  </SelectItem>
+                                ))}
+                              </SelectContent>
+                            </Select>
                           </div>
                         </div>
                       );


### PR DESCRIPTION
## Summary
- **Email block**: question + email input, validates as email on submission
- **Date block**: question + date picker input
- **Rating block**: question + 1–5 star interactive rating (amber stars, hover effect)
- **Dropdown block**: question + configurable options (reuses MultipleChoiceOption editor UI) + shadcn Select in form view

All 4 tools appear in the EditorJS toolbox and are fully rendered in the public form view.

## Test plan
- [ ] Open a form in the editor — all 4 new block types appear in the `/` toolbox
- [ ] Add each block type, fill in a question title, and verify save/reload persists the data
- [ ] Open the public form view — each block type renders the correct input
- [ ] Submit a form with all 4 new block types and verify submissions are recorded correctly
- [ ] Dropdown: add/remove options in the editor and confirm they appear in the form view select

🤖 Generated with [Claude Code](https://claude.com/claude-code)