### PR TITLE
chore: backend/frontend tests and GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [dev, main]
+
+jobs:
+  lint-and-typecheck:
+    name: Lint & Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npm run tsc --workspaces
+
+      - name: Lint
+        run: npm run lint --workspaces --if-present
+
+  test-backend:
+    name: Backend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run backend tests
+        run: npm test --workspace=backend
+        env:
+          JWT_SECRET: test-secret
+          NODE_ENV: test
+
+  test-frontend:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run frontend tests
+        run: npm test --workspace=client

--- a/backend/jest.config.ts
+++ b/backend/jest.config.ts
@@ -10,6 +10,7 @@ const config: Config = {
   moduleFileExtensions: ["ts", "js"],
   transformIgnorePatterns: ["<rootDir>/node_modules/"],
   testMatch: ["**/?(*.)+(spec|test).[t]s"],
+  setupFiles: ["<rootDir>/jest.env.ts"],
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
 };
 

--- a/backend/jest.env.ts
+++ b/backend/jest.env.ts
@@ -1,0 +1,4 @@
+// This file runs before any modules are imported (setupFiles).
+// It must set all env vars needed by top-level module code.
+process.env.JWT_SECRET = "test-secret";
+process.env.NODE_ENV = "test";

--- a/backend/jest.setup.ts
+++ b/backend/jest.setup.ts
@@ -2,16 +2,15 @@ import mongoose from "mongoose";
 import { MongoMemoryServer } from "mongodb-memory-server";
 import User from "./src/models/user";
 import Dashboard from "./src/models/dashboard";
+import Form from "./src/models/form";
+import Submission from "./src/models/submission";
 
 let mongoServer: MongoMemoryServer;
-jest.mock("jsonwebtoken", () => ({
-  sign: jest.fn(() => "mocked-jwt-token"),
-}));
+
 beforeAll(async () => {
   process.env.MONGOMS_DOWNLOAD_DIR = ".mongodb-binaries";
   mongoServer = await MongoMemoryServer.create();
   const uri = mongoServer.getUri();
-
   process.env.MONGO_URI = uri;
 
   if (mongoose.connection.readyState === 0) {
@@ -27,4 +26,6 @@ afterAll(async () => {
 beforeEach(async () => {
   await User.deleteMany({});
   await Dashboard.deleteMany({});
+  await Form.deleteMany({});
+  await Submission.deleteMany({});
 });

--- a/backend/src/tests/auth.test.ts
+++ b/backend/src/tests/auth.test.ts
@@ -2,49 +2,78 @@ import request from "supertest";
 import User from "../models/user";
 import { app } from "../app";
 
+const VALID_USER = {
+  fullName: "John Doe",
+  email: "john@example.com",
+  password: "Password1!",
+};
+
 describe("POST /api/auth/signup", () => {
-  it("should register a new user and return JWT token in cookies", async () => {
-    const res = await request(app).post("/api/auth/signup").send({
-      fullName: "John Doe",
-      email: "john@example.com",
-      password: "password123",
-    });
+  it("should register a new user and set jwt cookie", async () => {
+    const res = await request(app).post("/api/auth/signup").send(VALID_USER);
     expect(res.statusCode).toBe(201);
     expect(res.body.message).toBe("User registered successfully");
-    expect(res.body.user).toHaveProperty("email", "john@example.com");
+    expect(res.body.user).toHaveProperty("email", VALID_USER.email);
 
-    // Check JWT token in cookies
-    const cookies = res.headers["set-cookie"];
+    const cookies = res.headers["set-cookie"] as unknown as string[];
     expect(cookies).toBeDefined();
     expect(cookies[0]).toContain("jwt");
   });
 
   it("should return 409 if user already exists", async () => {
-    // Create a user first
     await new User({
       fullName: "John Doe",
       email: "john@example.com",
       password: "hashedpassword",
     }).save();
 
-    const res = await request(app).post("/api/auth/signup").send({
-      fullName: "John Doe",
-      email: "john@example.com",
-      password: "password123",
-    });
-
+    const res = await request(app).post("/api/auth/signup").send(VALID_USER);
     expect(res.statusCode).toBe(409);
     expect(res.body.message).toBe("User already exists with this email.");
   });
 
-  it("should return 400 for invalid data", async () => {
-    const res = await request(app).post("/api/auth/signup").send({
-      fullName: "", // Invalid fullName
-      email: "john@example.com",
-      password: "password123",
-    });
-
+  it("should return 400 for missing fullName", async () => {
+    const res = await request(app)
+      .post("/api/auth/signup")
+      .send({ ...VALID_USER, fullName: "" });
     expect(res.statusCode).toBe(400);
-    expect(res.body.message).toBe("Invalid Request"); // Adjust this based on your validation logic
+  });
+
+  it("should return 400 for a weak password", async () => {
+    const res = await request(app)
+      .post("/api/auth/signup")
+      .send({ ...VALID_USER, password: "weakpassword" });
+    expect(res.statusCode).toBe(400);
+  });
+});
+
+describe("POST /api/auth/login", () => {
+  beforeEach(async () => {
+    await request(app).post("/api/auth/signup").send(VALID_USER);
+  });
+
+  it("should login and set jwt cookie", async () => {
+    const res = await request(app)
+      .post("/api/auth/login")
+      .send({ email: VALID_USER.email, password: VALID_USER.password });
+    expect(res.statusCode).toBe(200);
+    expect(res.body.message).toBe("Login successful");
+
+    const cookies = res.headers["set-cookie"] as unknown as string[];
+    expect(cookies[0]).toContain("jwt");
+  });
+
+  it("should return 401 for wrong password", async () => {
+    const res = await request(app)
+      .post("/api/auth/login")
+      .send({ email: VALID_USER.email, password: "WrongPassword1!" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("should return 404 for unknown email", async () => {
+    const res = await request(app)
+      .post("/api/auth/login")
+      .send({ email: "nobody@example.com", password: VALID_USER.password });
+    expect(res.statusCode).toBe(404);
   });
 });

--- a/backend/src/tests/form.test.ts
+++ b/backend/src/tests/form.test.ts
@@ -1,0 +1,190 @@
+import request from "supertest";
+import { app } from "../app";
+import { signupAndGetWorkspaceId } from "./helpers";
+
+const makeFormPayload = (workspaceId: string) => ({
+  title: "My Test Form",
+  time: Date.now(),
+  version: "2.30.6",
+  workspaceId,
+  blocks: [
+    {
+      type: "shortAnswerTool",
+      data: { title: "What is your name?", placeholder: "", required: false },
+    },
+  ],
+});
+
+describe("POST /api/form", () => {
+  it("should create a form when authenticated", async () => {
+    const { cookie, workspaceId } = await signupAndGetWorkspaceId();
+    const res = await request(app)
+      .post("/api/form")
+      .set("Cookie", cookie)
+      .send(makeFormPayload(workspaceId));
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty("_id");
+    expect(res.body.title).toBe("My Test Form");
+  });
+
+  it("should return 401 without authentication", async () => {
+    const res = await request(app).post("/api/form").send({ title: "x" });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("GET /api/form/view-form/:formId", () => {
+  it("should return a public form without auth", async () => {
+    const { cookie, workspaceId } = await signupAndGetWorkspaceId();
+    const createRes = await request(app)
+      .post("/api/form")
+      .set("Cookie", cookie)
+      .send(makeFormPayload(workspaceId));
+    const formId = createRes.body._id as string;
+
+    const res = await request(app).get(`/api/form/view-form/${formId}`);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.title).toBe("My Test Form");
+  });
+
+  it("should return 404 for a non-existent form", async () => {
+    const res = await request(app).get("/api/form/view-form/000000000000000000000000");
+    expect(res.statusCode).toBe(404);
+  });
+});
+
+describe("GET /api/form/:formId", () => {
+  it("should return form data when authenticated as owner", async () => {
+    const { cookie, workspaceId } = await signupAndGetWorkspaceId();
+    const createRes = await request(app)
+      .post("/api/form")
+      .set("Cookie", cookie)
+      .send(makeFormPayload(workspaceId));
+    const formId = createRes.body._id as string;
+
+    const res = await request(app).get(`/api/form/${formId}`).set("Cookie", cookie);
+    expect(res.statusCode).toBe(200);
+    expect(res.body._id).toBe(formId);
+  });
+
+  it("should return 401 without authentication", async () => {
+    const res = await request(app).get("/api/form/000000000000000000000000");
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("PUT /api/form/:id", () => {
+  it("should update form title", async () => {
+    const { cookie, workspaceId } = await signupAndGetWorkspaceId();
+    const createRes = await request(app)
+      .post("/api/form")
+      .set("Cookie", cookie)
+      .send(makeFormPayload(workspaceId));
+    const formId = createRes.body._id as string;
+
+    const res = await request(app)
+      .put(`/api/form/${formId}`)
+      .set("Cookie", cookie)
+      .send({ ...makeFormPayload(workspaceId), title: "Updated Title" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.title).toBe("Updated Title");
+  });
+});
+
+describe("POST /api/form/submit-form", () => {
+  it("should accept a form submission without auth", async () => {
+    const { cookie, workspaceId } = await signupAndGetWorkspaceId();
+    const createRes = await request(app)
+      .post("/api/form")
+      .set("Cookie", cookie)
+      .send(makeFormPayload(workspaceId));
+    const form = createRes.body;
+
+    const res = await request(app)
+      .post("/api/form/submit-form")
+      .send({
+        _id: form._id,
+        title: form.title,
+        blocks: form.blocks.map((b: { type: string; data: object }) => ({
+          ...b,
+          data: { ...b.data, value: "Alice" },
+        })),
+      });
+
+    expect(res.statusCode).toBe(200);
+  });
+});
+
+describe("GET /api/form/submissions/:formId", () => {
+  it("should return submissions with pagination", async () => {
+    const { cookie, workspaceId } = await signupAndGetWorkspaceId();
+    const createRes = await request(app)
+      .post("/api/form")
+      .set("Cookie", cookie)
+      .send(makeFormPayload(workspaceId));
+    const form = createRes.body;
+
+    // Submit once
+    await request(app).post("/api/form/submit-form").send({
+      _id: form._id,
+      title: form.title,
+      blocks: form.blocks,
+    });
+
+    const res = await request(app)
+      .get(`/api/form/submissions/${form._id}?page=1&limit=10`)
+      .set("Cookie", cookie);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty("submissions");
+    expect(res.body).toHaveProperty("total");
+    expect(res.body.total).toBe(1);
+  });
+
+  it("should return 401 without authentication", async () => {
+    const res = await request(app).get("/api/form/submissions/000000000000000000000000");
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe("PUT /api/form/disable/:id", () => {
+  it("should toggle form disabled status", async () => {
+    const { cookie, workspaceId } = await signupAndGetWorkspaceId();
+    const createRes = await request(app)
+      .post("/api/form")
+      .set("Cookie", cookie)
+      .send(makeFormPayload(workspaceId));
+    const formId = createRes.body._id as string;
+
+    const res = await request(app).put(`/api/form/disable/${formId}`).set("Cookie", cookie);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+});
+
+describe("DELETE /api/form/:id", () => {
+  it("should delete a form and its submissions", async () => {
+    const { cookie, workspaceId } = await signupAndGetWorkspaceId();
+    const createRes = await request(app)
+      .post("/api/form")
+      .set("Cookie", cookie)
+      .send(makeFormPayload(workspaceId));
+    const formId = createRes.body._id as string;
+
+    const res = await request(app).delete(`/api/form/${formId}`).set("Cookie", cookie);
+
+    expect(res.statusCode).toBe(200);
+
+    // Confirm it's gone
+    const viewRes = await request(app).get(`/api/form/view-form/${formId}`);
+    expect(viewRes.statusCode).toBe(404);
+  });
+
+  it("should return 401 without authentication", async () => {
+    const res = await request(app).delete("/api/form/000000000000000000000000");
+    expect(res.statusCode).toBe(401);
+  });
+});

--- a/backend/src/tests/helpers.ts
+++ b/backend/src/tests/helpers.ts
@@ -1,0 +1,31 @@
+import request from "supertest";
+import { app } from "../app";
+
+const DEFAULT_USER = {
+  fullName: "Test User",
+  email: "test@example.com",
+  password: "Password1!",
+};
+
+/**
+ * Signs up a user via the API and returns the jwt cookie string
+ * for use in subsequent authenticated requests.
+ */
+export const signupAndGetCookie = async (user = DEFAULT_USER): Promise<{ cookie: string }> => {
+  const res = await request(app).post("/api/auth/signup").send(user);
+  const setCookie = res.headers["set-cookie"] as unknown as string[] | undefined;
+  const cookie = setCookie?.[0] ?? "";
+  return { cookie };
+};
+
+/**
+ * Signs up a user and fetches their dashboard to obtain a workspace ID.
+ */
+export const signupAndGetWorkspaceId = async (
+  user = DEFAULT_USER,
+): Promise<{ cookie: string; workspaceId: string }> => {
+  const { cookie } = await signupAndGetCookie(user);
+  const dashRes = await request(app).get("/api/dashboard").set("Cookie", cookie);
+  const workspaceId = dashRes.body.workspaces?.[0]?._id as string;
+  return { cookie, workspaceId };
+};

--- a/client/src/tests/components/ErrorBoundary.test.tsx
+++ b/client/src/tests/components/ErrorBoundary.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import ErrorBoundary from "@/components/common/ErrorBoundary";
+
+const Bomb = () => {
+  throw new Error("Test error");
+};
+
+describe("ErrorBoundary", () => {
+  // Suppress console.error noise from intentional throws
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders children when there is no error", () => {
+    render(
+      <ErrorBoundary>
+        <p>All good</p>
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText("All good")).toBeInTheDocument();
+  });
+
+  it("renders the fallback UI when a child throws", () => {
+    render(
+      <ErrorBoundary>
+        <Bomb />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /reload/i })).toBeInTheDocument();
+  });
+});

--- a/client/src/tests/components/RatingInput.test.tsx
+++ b/client/src/tests/components/RatingInput.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import RatingInput from "@/components/form/ui/RatingInput";
+
+describe("RatingInput", () => {
+  it("renders the correct number of stars", () => {
+    render(
+      <RatingInput
+        value={0}
+        maxRating={5}
+        onChange={() => {}}
+      />,
+    );
+    const stars = screen.getAllByRole("button");
+    expect(stars).toHaveLength(5);
+  });
+
+  it("calls onChange with the clicked star value", () => {
+    const onChange = vi.fn();
+    render(
+      <RatingInput
+        value={0}
+        maxRating={5}
+        onChange={onChange}
+      />,
+    );
+    const stars = screen.getAllByRole("button");
+    fireEvent.click(stars[2]); // 3rd star = rating 3
+    expect(onChange).toHaveBeenCalledWith(3);
+  });
+
+  it("highlights stars up to the current value", () => {
+    render(
+      <RatingInput
+        value={3}
+        maxRating={5}
+        onChange={() => {}}
+      />,
+    );
+    const stars = screen.getAllByRole("button");
+    // First 3 should be amber (#f59e0b), last 2 grey
+    expect(stars[0]).toHaveStyle({ color: "#f59e0b" });
+    expect(stars[2]).toHaveStyle({ color: "#f59e0b" });
+    expect(stars[3]).toHaveStyle({ color: "#d1d5db" });
+  });
+
+  it("respects a custom maxRating", () => {
+    render(
+      <RatingInput
+        value={0}
+        maxRating={3}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getAllByRole("button")).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
## Summary
- **Jest env fix**: `jest.env.ts` via `setupFiles` sets `JWT_SECRET` before any modules load, enabling real JWT auth in integration tests
- **Backend tests** (20 tests): auth (signup/login) + full form API CRUD, submit, pagination, disable, delete — with auth and without
- **Frontend tests** (6 tests): `RatingInput` (star count, click, highlight) + `ErrorBoundary` (happy path, catch/fallback)
- **CI pipeline** (`.github/workflows/ci.yml`): three parallel jobs on push/PR to `dev`/`main` — lint+typecheck, backend tests, frontend tests

## Test plan
- [ ] `npm test --workspace=backend` — 20 tests pass
- [ ] `npm test --workspace=client` — 8 tests pass (6 new + 2 existing)
- [ ] Open a PR to dev and confirm all 3 CI jobs go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)