### PR TITLE
feat: landing page revamp — hero, how-it-works, block types (Area 2)

### DIFF
--- a/client/src/pages/Landing.tsx
+++ b/client/src/pages/Landing.tsx
@@ -1,6 +1,7 @@
 import Logo from "@/components/svg/Logo";
 import { Button } from "@/components/ui/button";
 import { Link } from "react-router-dom";
+import { useAuth } from "@/contexts/AuthProvider";
 import {
   LayoutTemplate,
   Share2,
@@ -19,6 +20,7 @@ import {
 } from "lucide-react";
 
 const Landing = () => {
+  const { user } = useAuth();
   return (
     <main className="bg-background text-foreground">
       {/* ── Navbar ───────────────────────────────────────────────── */}
@@ -51,7 +53,7 @@ const Landing = () => {
               Features
             </a>
             <Link to="/dashboard">
-              <Button size="sm">Start free</Button>
+              <Button size="sm">{user ? "Dashboard" : "Start free"}</Button>
             </Link>
           </nav>
         </div>

--- a/client/src/tests/components/Landing.test.tsx
+++ b/client/src/tests/components/Landing.test.tsx
@@ -6,6 +6,12 @@ vi.mock("@/components/svg/Logo", () => ({
   default: () => <svg data-testid="logo" />,
 }));
 
+vi.mock("@/contexts/AuthProvider", () => ({
+  useAuth: vi.fn(() => ({ user: null, setUser: vi.fn() })),
+}));
+
+import { useAuth } from "@/contexts/AuthProvider";
+
 const renderLanding = () =>
   render(
     <MemoryRouter>
@@ -14,6 +20,23 @@ const renderLanding = () =>
   );
 
 describe("Landing page", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it("shows 'Start free' in navbar when logged out", () => {
+    vi.mocked(useAuth).mockReturnValue({ user: null, setUser: vi.fn() });
+    renderLanding();
+    expect(screen.getByRole("button", { name: /start free/i })).toBeInTheDocument();
+  });
+
+  it("shows 'Dashboard' in navbar when logged in", () => {
+    vi.mocked(useAuth).mockReturnValue({
+      user: { _id: "u1", fullName: "Alice", email: "a@b.com", avatar: "" },
+      setUser: vi.fn(),
+    });
+    renderLanding();
+    expect(screen.getByRole("button", { name: /dashboard/i })).toBeInTheDocument();
+  });
+
   it("renders without crashing", () => {
     renderLanding();
     expect(screen.getAllByText(/forminit/i).length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

- Replaces the old framer-motion landing with a Linear-inspired grid layout, then enriches it with hero copy, an editor mockup, how-it-works section, and block-type showcase
- Adds auth-aware navbar: logged-in users see a **Dashboard** button instead of **Start free**
- All landing content is static (no API calls); Supabase palette applied via rebase onto `dev`

## Test coverage

- `Landing.test.tsx` — renders without crashing, CTA links to `/dashboard`, 6 feature items, no framer-motion
- New assertions: `shows 'Start free' when logged out`, `shows 'Dashboard' when logged in` (both mock `useAuth`)
- All 20 client tests pass ✅

## Checklist

- [x] CLAUDE.md updated if models/routes/architecture changed — no changes needed (UI only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)