### PR TITLE
fix: correct render.yaml MONGO_URI key and remove missing CHANGELOG copy

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -20,8 +20,6 @@ WORKDIR /app
 COPY --from=build /app/backend/dist /app/backend/dist
 COPY --from=build /app/backend/package*.json /app/backend/
 COPY --from=build /app/package*.json /app/
-COPY --from=build /app/backend/CHANGELOG.md /app/backend/CHANGELOG.md
-
 RUN npm install --only=production
 
 EXPOSE 3000

--- a/render.yaml
+++ b/render.yaml
@@ -12,7 +12,7 @@ services:
         value: staging
       - key: PORT
         value: 3000
-      - key: MONGODB_URI
+      - key: MONGO_URI
         sync: false
       - key: JWT_SECRET
         sync: false
@@ -38,7 +38,7 @@ services:
         value: production
       - key: PORT
         value: 3000
-      - key: MONGODB_URI
+      - key: MONGO_URI
         sync: false
       - key: JWT_SECRET
         sync: false


### PR DESCRIPTION
## Summary
- `render.yaml` had `MONGODB_URI` but backend reads `MONGO_URI` — would have caused DB connection failure on first deploy
- `Dockerfile.prod` was copying `backend/CHANGELOG.md` which doesn't exist — would have failed the production build

## Test plan
- [ ] Render Blueprint deploy succeeds without build errors
- [ ] `GET /api/health` returns `{"status":"ok"}` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)