### PR TITLE
release: v0.16.0 — deployment setup + cross-origin cookie fix

### DIFF
--- a/backend/src/controllers/authentication.ts
+++ b/backend/src/controllers/authentication.ts
@@ -15,8 +15,8 @@ export const signup = async (req: Request, res: Response): Promise<void> => {
     });
     res.cookie("jwt", token, {
       httpOnly: true,
-      secure: process.env.NODE_ENV === "production", // Secure flag for production (only HTTPS)
-      sameSite: "strict", // Protects against CSRF attacks
+      secure: ["production", "staging"].includes(process.env.NODE_ENV || ""),
+      sameSite: ["production", "staging"].includes(process.env.NODE_ENV || "") ? "none" : "strict",
       maxAge: 3600000, //ms = 1 hour
     });
     res.status(201).json({
@@ -38,8 +38,8 @@ export const login = async (req: Request, res: Response) => {
     // Set the token in an HTTP-only cookie
     res.cookie("jwt", token, {
       httpOnly: true,
-      secure: process.env.NODE_ENV === "production", // Secure flag for production (only HTTPS)
-      sameSite: "strict", // Protects against CSRF attacks
+      secure: ["production", "staging"].includes(process.env.NODE_ENV || ""),
+      sameSite: ["production", "staging"].includes(process.env.NODE_ENV || "") ? "none" : "strict",
       maxAge: 3600000, //ms = 1 hour
     });
     // Return the JWT token and user information
@@ -60,8 +60,8 @@ export const google = async (req: Request, res: Response): Promise<void> => {
     );
     res.cookie("jwt", token, {
       httpOnly: true,
-      secure: process.env.NODE_ENV === "production", // Secure flag for production (only HTTPS)
-      sameSite: "strict", // Protects against CSRF attacks
+      secure: ["production", "staging"].includes(process.env.NODE_ENV || ""),
+      sameSite: ["production", "staging"].includes(process.env.NODE_ENV || "") ? "none" : "strict",
       maxAge: 3600000, //ms = 1 hour
     });
     res.status(200).json({


### PR DESCRIPTION
## Summary
- Rename forminit → lumiform across all client, backend, and config files
- Add Sentry error tracking
- Add `/api/health` liveness endpoint
- Add `DEPLOYMENT.md` and `render.yaml` for Render Blueprint
- Fix `render.yaml` env key and `Dockerfile.prod` build error
- Fix form test payloads and Submission BlockSchema for Sprint 8a block `_id`
- Fix JWT cookie `SameSite=None` for cross-origin deployed environments

## Test plan
- [x] All CI checks green on dev
- [ ] Login and dashboard load on https://lumiform.pages.dev after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)