### PR TITLE
feat: add global top progress bar

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,3 +1,15 @@
+@keyframes topbar-progress {
+  0% {
+    transform: translateX(-100%);
+  }
+  50% {
+    transform: translateX(0%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
 /* Placeholder for contenteditable blocks */
 [contenteditable][data-placeholder]:empty::before {
   content: attr(data-placeholder);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,6 +12,7 @@ import { routes } from "./Routes";
 import { Suspense } from "react";
 import SuspenseLayout from "./layouts/SuspenseLayout";
 import ErrorBoundary from "./components/common/ErrorBoundary";
+import TopProgressBar from "./components/common/TopProgressBar";
 
 const queryClient = new QueryClient();
 
@@ -31,6 +32,7 @@ function App() {
                     <RouterProvider router={routes} />
                   </Suspense>
                 </AuthProvider>
+                <TopProgressBar />
                 <ReactQueryDevtools initialIsOpen={false} />
                 <Toaster />
               </QueryClientProvider>

--- a/client/src/components/common/TopProgressBar.tsx
+++ b/client/src/components/common/TopProgressBar.tsx
@@ -1,0 +1,17 @@
+import { useIsFetching } from "@tanstack/react-query";
+
+const TopProgressBar = () => {
+  const isFetching = useIsFetching();
+
+  return (
+    <div
+      className={`fixed top-0 left-0 right-0 z-50 h-0.5 transition-opacity duration-500 ${
+        isFetching ? "opacity-100" : "opacity-0"
+      }`}
+    >
+      <div className="h-full w-full animate-[topbar-progress_1.5s_ease-in-out_infinite] bg-primary" />
+    </div>
+  );
+};
+
+export default TopProgressBar;


### PR DESCRIPTION
## Summary
- Adds a fixed top bar that animates during any active react-query fetch
- Uses `useIsFetching()` — no extra state or dependencies needed
- Fades in/out via opacity transition; indeterminate slide animation via CSS keyframe
- Uses `bg-primary` so it respects the app theme

## Test plan
- [ ] Throttle network to Slow 3G in DevTools, navigate to Dashboard — bar should appear and slide while data loads
- [ ] On fast network, bar should flash briefly and disappear
- [ ] Dark and light mode — bar colour should match primary

🤖 Generated with [Claude Code](https://claude.com/claude-code)