### PR TITLE
feat: add Lumifeed feedback widget

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -23,5 +23,13 @@
       type="module"
       src="/src/main.tsx"
     ></script>
+    <script
+      src="https://staging.lumifeed.app/widget/lumifeed-widget.iife.js"
+      data-lumifeed-key="fp_live_yakzw1GCAAgRhMiK55k1KxkIZTDGJh38UClDdabWHas"
+      data-base-url="https://staging.lumifeed.app"
+      data-theme="auto"
+      data-position="bottom-right"
+      async
+    ></script>
   </body>
 </html>

--- a/client/index.html
+++ b/client/index.html
@@ -25,7 +25,7 @@
     ></script>
     <script
       src="https://staging.lumifeed.app/widget/lumifeed-widget.iife.js"
-      data-lumifeed-key="fp_live_yakzw1GCAAgRhMiK55k1KxkIZTDGJh38UClDdabWHas"
+      data-lumifeed-key="fp_live_UuGf9UFYN0jUQf_GuqI-sRMYbV-ANsAyyVuM-6R6OO8"
       data-base-url="https://staging.lumifeed.app"
       data-theme="auto"
       data-position="bottom-right"


### PR DESCRIPTION
## Summary
- Adds Lumifeed feedback widget script to `client/index.html`
- Widget points to `staging.lumifeed.app` with auto theme, bottom-right position

## Test plan
- [ ] Open the app and verify the Lumifeed widget appears in the bottom-right corner
- [ ] Test on both light and dark themes (auto theme should adapt)
- [ ] Confirm no console errors related to the widget script

🤖 Generated with [Claude Code](https://claude.com/claude-code)